### PR TITLE
Update types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ declare global {
       env(object: PluginEnvOptions): void;
     }
     interface TestConfigOverrides {
-      env?: PluginEnvOptions
+      env?: Partial<PluginEnvOptions>
     }
   }
 }


### PR DESCRIPTION
typescript check in our repo throws error:
```
node_modules/cypress-plugin-xhr-toggle/dist/types.d.ts(37,13): error TS2717: Subsequent property declarations must have the same type.  Property 'env' must be of type 'Partial<PluginEnvOptions> | undefined', but here has type 'PluginEnvOptions | undefined'.
```

I believe this might fix it...?