### PR TITLE
ci: fix semantic-release permissions and update actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,17 @@
 name: e2e-tests
 on: [push]
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           build: npm run build
       - name: Semantic Release
@@ -17,5 +21,5 @@ jobs:
         with:
           branch: main
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Use built-in `GITHUB_TOKEN` instead of custom `GH_TOKEN` secret (bad credentials / 401)
- Add `contents: write`, `issues: write`, `pull-requests: write` permissions for semantic-release
- Update `actions/checkout` to v4 and `cypress-io/github-action` to v6 (Node.js 20 deprecation)

## Test plan
- [ ] Merge to main and verify semantic-release step succeeds